### PR TITLE
Update jest to v23.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "eslint-plugin-import": "^2.7.0",
-    "jest": "^22.2.2",
+    "jest": "^23.6.0",
     "smee-client": "^1.0.1",
     "standard": "^11.0.0"
   },


### PR DESCRIPTION
When cloning the repo, running `npm install` and then `npm test`, I see the following error:

```
❯ npm test

> probot-autoresponder@0.1.0 test /Users/macklinu/dev/probot/autoresponder
> jest && standard

 FAIL  test/index.test.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.527s
Ran all test suites.
npm ERR! Test failed.  See above for more details.
```

I believe this is related to https://github.com/facebook/jest/issues/6766, and updating to the latest version of Jest resolves this issue (tests pass locally):

```
❯ npm test

> probot-autoresponder@0.1.0 test /Users/macklinu/dev/probot/autoresponder
> jest && standard

 PASS  test/index.test.js
  autoresponder
    ✓ posts a comment (7ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.855s
Ran all test suites.
```