### PR TITLE
Update getContent() method to getContents()

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = robot => {
   robot.on('issues.opened', async context => {
     const options = context.repo({path: '.github/ISSUE_REPLY_TEMPLATE.md'})
-    const res = await context.github.repos.getContent(options)
+    const res = await context.github.repos.getContents(options)
     const template = Buffer.from(res.data.content, 'base64').toString()
 
     return context.github.issues.createComment(context.issue({body: template}))


### PR DESCRIPTION
repos.getContent() is deprecated now and is replaced by repos.getContents().
